### PR TITLE
feat(sentiment): add batch processing for sentiment analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+env
+__pycache__
+*.pyc
+static/audio/*
+.Ds_Store

--- a/app/data/sentiment_data.py
+++ b/app/data/sentiment_data.py
@@ -42,6 +42,22 @@ class SentimentDataLayer:
             print(f"[error] [Data Layer] [SentimentDataLayer] [analyze] An error occurred during sentiment analysis: {str(e)}")
             return {'error': f'An unexpected error occurred while processing the request.'}  # Generic error message
         
+    def analyze_batch(self, texts: list) -> list:
+        """
+        Perform sentiment analysis on a list of texts.
+        :param texts: List of input texts.
+        :return: List of dictionaries each with predicted label and confidence.
+        """
+        try:
+            # Call the batch_forward method on the underlying model
+            results = self.model.batch_forward(texts)
+            return results
+        
+        except Exception as e:
+            print(f"[error] [Data Layer] [SentimentDataLayer] [analyze_batch] An error occurred: {str(e)}")
+            # Return an error for each text in case of failure
+            return [{"error": "An unexpected error occurred while processing batch request."} for _ in texts]
+        
 
 # if __name__ == "__main__":
 #     config = {

--- a/app/models/bertweet_model.py
+++ b/app/models/bertweet_model.py
@@ -61,6 +61,29 @@ class BertweetSentiment(nn.Module):
         predicted_label = self.class_labels[predicted_class]
 
         return outputs, probabilities, predicted_label, probabilities[0][predicted_class].item()
+    
+    def batch_forward(self, texts: list) -> list:
+        """
+        Perform sentiment analysis on a list of texts in batch.
+        Args:
+            texts (list): List of input texts for sentiment analysis.
+        Returns:
+            list: A list of dictionaries with 'label' and 'confidence' for each text.
+        """
+        # Batch tokenize the texts
+        inputs = self.tokenizer(texts, return_tensors="pt", truncation=True, padding=True).to(self.device)
+        outputs = self.model(**inputs)
+        probabilities = torch.nn.functional.softmax(outputs.logits, dim=-1)
+        results = []
+        for i in range(probabilities.size(0)):
+            predicted_class = torch.argmax(probabilities[i]).item()
+            predicted_label = self.class_labels[predicted_class]
+            confidence = probabilities[i][predicted_class].item()
+            results.append({
+                "label": predicted_label,
+                "confidence": confidence
+            })
+        return results
 
 
 if __name__ == "__main__":

--- a/app/routes/audio_transcript_sentiment_routes.py
+++ b/app/routes/audio_transcript_sentiment_routes.py
@@ -100,7 +100,9 @@ def register_routes(api):
                 
 
                 # Call the service to perform sentiment analysis on the audio transcript
-                result = service.process(url = url, start_time_ms = start_time_ms, end_time_ms = end_time_ms)
+                # result = service.process(url = url, start_time_ms = start_time_ms, end_time_ms = end_time_ms)
+                result = service.process_batch(url = url, start_time_ms = start_time_ms, end_time_ms = end_time_ms)
+                
 
                 if 'error' in result:
                     return {

--- a/app/services/sentiment_service.py
+++ b/app/services/sentiment_service.py
@@ -37,6 +37,21 @@ class SentimentService:
         except Exception as e:
             print(f"[error] [Service Layer] [SentimentService] [analyze] An error occurred during sentiment analysis: {str(e)}")
             return {'error': f'An unexpected error occurred while processing the request.'}  # Generic error message
+    
+    def analyze_batch(self, texts: list) -> list:
+        """
+        Perform sentiment analysis on a list of texts.
+        :param texts: List of input texts.
+        :return: List of dictionaries each with predicted label and confidence
+        """
+        try:
+            results = self.sentiment_data_layer.analyze_batch(texts)
+            return results
+        
+        except Exception as e:
+            print(f"[error] [Service Layer] [SentimentService] [analyze_batch] An error occurred: {str(e)}")
+            return [{"error": "An unexpected error occurred while processing batch request."} for _ in texts]
+
         
 
 # if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces batch processing for sentiment analysis to reduce inference time when processing multiple transcript chunks. The changes include:

- A new `batch_forward()` method in the BertweetSentiment model to handle a list of texts.
- A new `analyze_batch()` function in the sentiment data layer that leverages the model’s batch method.
- A corresponding `analyze_batch()` function in the sentiment service layer.
- Updating the process function in the service layer to collect chunk texts and process them in a batch.

### Notes
- Benchmark tests indicate a modest reduction in overall processing time (batch: ~15.84s vs. normal: ~18.66s), though the improvement may vary depending on the input length and number of chunks.


Please review and provide feedback.
