### PR TITLE
refactor: remove unused imports and variables

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ from flask import Flask,request
 from flask_cors import CORS
 from flask_restx import Api 
 
-from app.utils.logger import requests_logger,logger
+from app.utils.logger import requests_logger
 
 from app.routes import register_routes
 

--- a/app/models/whisper_model.py
+++ b/app/models/whisper_model.py
@@ -1,7 +1,5 @@
 """
 This module defines the WhisperTranscript class, which is a PyTorch model for transcribing audio files using the OpenAI Whisper model.
-"""
-import torch
 import torch.nn as nn
 
 from transformers import pipeline

--- a/app/routes/audio_transcript_sentiment_routes.py
+++ b/app/routes/audio_transcript_sentiment_routes.py
@@ -141,7 +141,7 @@ def register_routes(api):
                 }, 200
 
 
-            except Exception as e:
+            except Exception:
                 return {
                     'status': 'error',
                     'error': 'An unexpected error occurred while processing the request.', # Generic error message

--- a/app/services/audio_transcription_sentiment_pipeline.py
+++ b/app/services/audio_transcription_sentiment_pipeline.py
@@ -100,7 +100,6 @@ class AudioTranscriptionSentimentPipeline:
 
             # Step(3) Perform sentiment [Per chunk :D]
             for chunk in chunks:
-                timestamp = chunk['timestamp']
                 text = chunk['text']
 
                 sentiment_result = self.sentiment_service.analyze(text)


### PR DESCRIPTION
### Description
This PR cleans up the codebase by removing unused code (imports and variables) discovered by running the `flake8` linter.

### Changes Made
- **`app/__init__.py`**: Removed the unused `logger` import.
- **`app/models/whisper_model.py`**: Removed the unused `import torch`.
- **`app/routes/audio_transcript_sentiment_routes.py`**: Removed the unused `e` variable in the exception block.
- **`app/services/audio_transcription_sentiment_pipeline.py`**: Removed the unused `timestamp = chunk['timestamp']` variable assignment, which was declared but never utilized.

### Motivation
Removing dead code improves maintainability, prevents developer confusion, and ensures the codebase adheres more closely to strict Python linting standards (`flake8`), which is great for long-term project health.
