### PR TITLE
feat(multimodal): add MultimodalSentimentEngine, ProsodyService and /analyze/multimodal endpoint

### DIFF
--- a/app/routes/multimodal_routes.py
+++ b/app/routes/multimodal_routes.py
@@ -1,0 +1,200 @@
+"""
+Routes for the multimodal sentiment analysis endpoint.
+
+Exposes POST /multimodal/analyze — accepts any combination of text,
+pre-computed facial emotions, and audio path, and returns a fused
+sentiment prediction from the MultimodalSentimentEngine.
+
+Thread safety note:
+    The engine is a module-level singleton. Per-request weight overrides
+    are passed as arguments to engine.analyze() and are never written back
+    to engine.weights. Concurrent requests cannot overwrite each other's
+    weight configurations under gunicorn or any threaded WSGI server.
+"""
+
+from flask_restx import Namespace, Resource, fields
+from flask import request
+from app.services.multimodal_engine import MultimodalSentimentEngine
+from app.utils.logger import logger
+
+engine = MultimodalSentimentEngine()
+
+
+def register_routes(api):
+
+    multimodal_request_model = api.model('MultimodalRequest', {
+        'text': fields.String(
+            description='Transcribed text from the audio segment.',
+            example='This interface is really confusing.'
+        ),
+        'facial_emotions': fields.Raw(
+            description=(
+                'Dict of {emotion_label: percentage} from the '
+                'facial-sentiment-analysis-api /process_video endpoint. '
+                'Example: {"Happy": 12.5, "Neutral": 61.0, "Sad": 26.5}'
+            )
+        ),
+        'audio_path': fields.String(
+            description='Server-side path to the audio file for prosody extraction.',
+            example='static/audio/session_01_task_03.mp3'
+        ),
+        'start_ms': fields.Integer(
+            default=0,
+            description='Segment start time in milliseconds.'
+        ),
+        'end_ms': fields.Integer(
+            description='Segment end time in milliseconds.'
+        ),
+        'weights': fields.Raw(
+            description=(
+                'Optional per-request modality weight override. '
+                'Example: {"text": 0.6, "facial": 0.3, "prosody": 0.1}'
+            )
+        )
+    })
+
+    multimodal_success_model = api.model('MultimodalSuccess', {
+        'status': fields.String(example='success'),
+        'data': fields.Raw(
+            description=(
+                'Fused prediction with per-modality breakdown. '
+                'All labels normalized to: positive | neutral | negative.'
+            ),
+            example={
+                'fused_label': 'negative',
+                'fused_confidence': 0.6823,
+                'modality_scores': {
+                    'text': {
+                        'label': 'negative',
+                        'confidence': 0.87,
+                        'weight': 0.45
+                    },
+                    'facial': {
+                        'label': 'neutral',
+                        'confidence': 0.61,
+                        'weight': 0.35
+                    },
+                    'prosody': {
+                        'label': 'negative',
+                        'confidence': 0.42,
+                        'weight': 0.20
+                    }
+                }
+            }
+        )
+    })
+
+    multimodal_bad_request_model = api.model('MultimodalBadRequest', {
+        'status': fields.String(example='error'),
+        'error':  fields.String(
+            example='At least one modality must be provided.'
+        ),
+        'data':   fields.Raw(example=None)
+    })
+
+    multimodal_server_error_model = api.model('MultimodalServerError', {
+        'status': fields.String(example='error'),
+        'error':  fields.String(
+            example='An unexpected error occurred while processing the request.'
+        ),
+        'data':   fields.Raw(example=None)
+    })
+
+    @api.route('/analyze')
+    class MultimodalAnalyze(Resource):
+
+        @api.doc(
+            description=(
+                'Fuse facial expression, transcribed text sentiment, and '
+                'voice prosody into a single sentiment prediction. '
+                'At least one modality must be provided. Missing modalities '
+                'are skipped and their weight redistributed to available ones. '
+                'All output labels are normalized to: positive | neutral | negative.'
+            )
+        )
+        @api.expect(multimodal_request_model)
+        @api.response(200, 'Success', multimodal_success_model)
+        @api.response(400, 'Bad Request', multimodal_bad_request_model)
+        @api.response(500, 'Internal Server Error', multimodal_server_error_model)
+        def post(self):
+            """
+            Multimodal sentiment fusion from facial, text, and prosody signals.
+            """
+            try:
+                data = request.json
+
+                if not data:
+                    return {
+                        'status': 'error',
+                        'error':  'Request body must be valid JSON.',
+                        'data':   None
+                    }, 400
+
+                text            = data.get('text')
+                facial_emotions = data.get('facial_emotions')
+                audio_path      = data.get('audio_path')
+
+                has_text    = bool(text and text.strip())
+                has_facial  = bool(facial_emotions)
+                has_prosody = bool(
+                    audio_path and data.get('end_ms') is not None
+                )
+
+                if not any([has_text, has_facial, has_prosody]):
+                    return {
+                        'status': 'error',
+                        'error': (
+                            'At least one modality must be provided: '
+                            'text, facial_emotions, or audio_path + end_ms.'
+                        ),
+                        'data': None
+                    }, 400
+
+                # Build per-request weights without mutating the singleton.
+                # Each request gets its own copy of the defaults, then
+                # applies its own overrides on top — thread safe.
+                request_weights = dict(engine.weights)
+                if data.get('weights'):
+                    override = data['weights']
+                    if not isinstance(override, dict):
+                        return {
+                            'status': 'error',
+                            'error':  'weights must be a JSON object.',
+                            'data':   None
+                        }, 400
+                    request_weights.update(override)
+
+                result = engine.analyze(
+                    text=text if has_text else None,
+                    facial_emotions=facial_emotions if has_facial else None,
+                    audio_path=audio_path if has_prosody else None,
+                    start_ms=data.get('start_ms', 0),
+                    end_ms=data.get('end_ms'),
+                    weights=request_weights
+                )
+
+                if 'error' in result:
+                    return {
+                        'status': 'error',
+                        'error':  result['error'],
+                        'data':   None
+                    }, 500
+
+                return {
+                    'status': 'success',
+                    'data':   result
+                }, 200
+
+            except Exception as e:
+                logger.error(
+                    "[MultimodalAnalyze] Unexpected error: %s", str(e)
+                )
+                return {
+                    'status': 'error',
+                    'error':  'An unexpected error occurred while processing the request.',
+                    'data':   None
+                }, 500
+
+
+api = Namespace('Multimodal', description='Multimodal Sentiment Operations')
+register_routes(api)

--- a/app/services/multimodal_engine.py
+++ b/app/services/multimodal_engine.py
@@ -1,0 +1,206 @@
+"""
+MultimodalSentimentEngine — fuses facial, text, and voice prosody signals
+into a single confidence-weighted sentiment prediction.
+
+Design decisions:
+- All three modalities map to a common 3-class label space
+  ('positive', 'neutral', 'negative') before fusion.
+- Missing modalities are skipped and their weight is redistributed
+  proportionally to the available modalities.
+- Per-request weight overrides are passed as arguments, not mutations
+  of the shared singleton, to avoid race conditions under concurrent load.
+"""
+
+from app.services.sentiment_service import SentimentService
+from app.services.prosody_service import ProsodyService
+from app.utils.logger import logger
+
+
+DEFAULT_WEIGHTS = {
+    'text':    0.45,
+    'facial':  0.35,
+    'prosody': 0.20
+}
+
+LABEL_MAP = {
+    'POS': 'positive',
+    'NEU': 'neutral',
+    'NEG': 'negative',
+    'Happy':     'positive',
+    'Surprised': 'positive',
+    'Neutral':   'neutral',
+    'Sad':       'negative',
+    'Angry':     'negative',
+    'Fearful':   'negative',
+    'Disgusted': 'negative',
+    'positive': 'positive',
+    'neutral':  'neutral',
+    'negative': 'negative',
+}
+
+
+class MultimodalSentimentEngine:
+    """
+    Fuses facial expression, transcribed text sentiment, and voice prosody
+    into a single sentiment prediction per audio-visual chunk.
+
+    The engine is designed as a module-level singleton in the route layer.
+    Per-request weight overrides are passed as method arguments — not
+    mutations of self.weights — so that concurrent requests cannot
+    overwrite each other's weight configurations.
+    """
+
+    def __init__(self, weights: dict = None):
+        self.weights = weights or dict(DEFAULT_WEIGHTS)
+        self.sentiment_service = SentimentService()
+        self.prosody_service = ProsodyService()
+
+    def analyze(
+        self,
+        text: str = None,
+        facial_emotions: dict = None,
+        audio_path: str = None,
+        start_ms: int = 0,
+        end_ms: int = None,
+        weights: dict = None,
+    ) -> dict:
+        """
+        Fuse available modalities into a single sentiment prediction.
+
+        At least one of text, facial_emotions, or audio_path must be
+        provided. Missing modalities are skipped and their weight is
+        redistributed proportionally to the available ones.
+
+        Args:
+            text           : transcribed text for the segment
+            facial_emotions: dict of {emotion_label: percentage} from
+                             the facial-sentiment-analysis-api
+            audio_path     : path to the audio file for prosody extraction
+            start_ms       : segment start time in milliseconds
+            end_ms         : segment end time in milliseconds
+            weights        : per-request weight override dict
+                             (does NOT mutate the engine's default weights)
+
+        Returns:
+            dict with fused_label, fused_confidence, modality_scores
+            or {'error': str} if no modality produced a valid result.
+        """
+        active_weights = weights if weights is not None else self.weights
+        scores = {}
+
+        # --- Text modality ---
+        if text and text.strip():
+            try:
+                result = self.sentiment_service.analyze(text)
+                if 'error' not in result:
+                    normalized_label = LABEL_MAP.get(
+                        result['label'], 'neutral'
+                    )
+                    scores['text'] = {
+                        'label':      normalized_label,
+                        'confidence': float(result['confidence']),
+                        'weight':     active_weights.get('text', 0.45)
+                    }
+                    logger.debug(
+                        "[MultimodalEngine] Text: %s (%.3f)",
+                        normalized_label, result['confidence']
+                    )
+            except Exception as e:
+                logger.error(
+                    "[MultimodalEngine] Text modality failed: %s", str(e)
+                )
+
+        # --- Facial modality ---
+        # Integration boundary: the facial API processes video files and
+        # returns frame-level emotion percentages via POST /process_video.
+        # The engine receives these as a pre-aggregated dict, keeping the
+        # fusion layer decoupled from the streaming architecture of the
+        # facial API. Temporal alignment (Deliverable G9) will handle the
+        # case where frame-level outputs need to be matched to audio chunk
+        # timestamps before aggregation.
+        if facial_emotions:
+            try:
+                if not isinstance(facial_emotions, dict):
+                    raise ValueError(
+                        "facial_emotions must be a dict of {label: percentage}"
+                    )
+                dominant = max(facial_emotions, key=facial_emotions.get)
+                confidence = facial_emotions[dominant] / 100.0
+                normalized_label = LABEL_MAP.get(dominant, 'neutral')
+                scores['facial'] = {
+                    'label':      normalized_label,
+                    'confidence': round(float(confidence), 4),
+                    'weight':     active_weights.get('facial', 0.35)
+                }
+                logger.debug(
+                    "[MultimodalEngine] Facial: %s (%.3f)",
+                    normalized_label, confidence
+                )
+            except Exception as e:
+                logger.error(
+                    "[MultimodalEngine] Facial modality failed: %s", str(e)
+                )
+
+        # --- Prosody modality ---
+        if audio_path and end_ms is not None:
+            try:
+                prosody = self.prosody_service.extract(
+                    audio_path, start_ms, end_ms
+                )
+                if prosody:
+                    scores['prosody'] = {
+                        'label':      prosody['valence_estimate'],
+                        'confidence': prosody['valence_score'],
+                        'weight':     active_weights.get('prosody', 0.20)
+                    }
+                    logger.debug(
+                        "[MultimodalEngine] Prosody: %s (%.3f)",
+                        prosody['valence_estimate'],
+                        prosody['valence_score']
+                    )
+            except Exception as e:
+                logger.error(
+                    "[MultimodalEngine] Prosody modality failed: %s", str(e)
+                )
+
+        if not scores:
+            logger.error(
+                "[MultimodalEngine] No modality produced a valid result."
+            )
+            return {'error': 'No modality produced a valid result.'}
+
+        return self._fuse(scores)
+
+    def _fuse(self, scores: dict) -> dict:
+        """
+        Confidence-weighted vote across available modalities.
+
+        Missing modalities are skipped and their weight is redistributed
+        proportionally so that total weight always sums to 1.0.
+        """
+        total_raw_weight = sum(v['weight'] for v in scores.values())
+
+        label_buckets = {
+            'positive': 0.0,
+            'neutral':  0.0,
+            'negative': 0.0
+        }
+
+        for modality, data in scores.items():
+            normalized_w = data['weight'] / total_raw_weight
+            label = data['label']
+            label_buckets[label] += normalized_w * data['confidence']
+
+        fused_label = max(label_buckets, key=label_buckets.get)
+        fused_confidence = round(label_buckets[fused_label], 4)
+
+        logger.debug(
+            "[MultimodalEngine] Fused: %s (%.4f) from %d modalities",
+            fused_label, fused_confidence, len(scores)
+        )
+
+        return {
+            'fused_label':      fused_label,
+            'fused_confidence': fused_confidence,
+            'modality_scores':  scores
+        }

--- a/app/services/prosody_service.py
+++ b/app/services/prosody_service.py
@@ -1,0 +1,176 @@
+"""
+Service layer for extracting voice prosody features from audio segments.
+
+Prosody features (pitch, energy, speaking rate, pitch perturbation) are
+used as a lightweight third modality in the MultimodalSentimentEngine.
+No trained model is required — rule-based valence estimation is used,
+with speaker-relative thresholds to avoid gender bias.
+"""
+
+import librosa
+import numpy as np
+from app.utils.logger import logger
+
+
+class ProsodyService:
+    """
+    Extracts low-level acoustic features from a bounded audio segment.
+
+    Speaker baselines (pitch and energy) are tracked across chunks within
+    a session so that valence estimation uses relative changes rather than
+    absolute thresholds. Call reset_baseline() between separate sessions.
+    """
+
+    def __init__(self):
+        self._session_pitch_baseline = None
+        self._session_energy_baseline = None
+        self._energy_history = []
+
+    def reset_baseline(self):
+        """
+        Reset speaker baselines between usability sessions.
+        Must be called when switching to a new participant or session.
+        """
+        self._session_pitch_baseline = None
+        self._session_energy_baseline = None
+        self._energy_history = []
+        logger.debug("[ProsodyService] Session baseline reset.")
+
+    def extract(self, audio_path: str, start_ms: int, end_ms: int) -> dict:
+        """
+        Extract prosody features from a time-bounded audio segment.
+
+        Args:
+            audio_path : path to the audio file
+            start_ms   : segment start time in milliseconds
+            end_ms     : segment end time in milliseconds
+
+        Returns:
+            dict with keys:
+                mean_pitch_hz            : float
+                pitch_std                : float
+                mean_energy              : float
+                speaking_rate            : float
+                pitch_perturbation_ratio : float (NOT clinical jitter)
+                valence_estimate         : str
+                valence_score            : float (0.0-1.0 confidence)
+        """
+        try:
+            duration_s = (end_ms - start_ms) / 1000.0
+            offset_s = start_ms / 1000.0
+
+            y, sr = librosa.load(
+                audio_path,
+                offset=offset_s,
+                duration=duration_s
+            )
+
+            if len(y) == 0:
+                logger.warning(
+                    "[ProsodyService] Empty audio segment: %s [%d-%d ms]",
+                    audio_path, start_ms, end_ms
+                )
+                return {}
+
+            f0, voiced_flag, _ = librosa.pyin(
+                y,
+                fmin=librosa.note_to_hz('C2'),
+                fmax=librosa.note_to_hz('C7')
+            )
+
+            voiced_f0 = f0[voiced_flag] if voiced_flag.any() else np.array([])
+
+            mean_pitch = float(np.mean(voiced_f0)) if len(voiced_f0) > 0 else 0.0
+            pitch_std = float(np.std(voiced_f0)) if len(voiced_f0) > 0 else 0.0
+
+            if len(voiced_f0) > 0:
+                if self._session_pitch_baseline is None:
+                    self._session_pitch_baseline = mean_pitch
+                else:
+                    self._session_pitch_baseline = (
+                        0.8 * self._session_pitch_baseline + 0.2 * mean_pitch
+                    )
+
+            rms = librosa.feature.rms(y=y)
+            mean_energy = float(np.mean(rms))
+
+            self._energy_history.append(mean_energy)
+            if self._session_energy_baseline is None:
+                self._session_energy_baseline = mean_energy
+            else:
+                self._session_energy_baseline = float(
+                    np.mean(self._energy_history[-10:])
+                )
+
+            speaking_rate = float(
+                np.sum(voiced_flag) / max(len(voiced_flag), 1)
+            )
+
+            pitch_perturbation_ratio = 0.0
+            if len(voiced_f0) > 1:
+                diffs = np.abs(np.diff(voiced_f0))
+                pitch_perturbation_ratio = float(
+                    np.mean(diffs) / (np.mean(voiced_f0) + 1e-8)
+                )
+
+            valence_label, valence_score = self._estimate_valence(
+                mean_pitch, pitch_std, mean_energy, speaking_rate
+            )
+
+            return {
+                'mean_pitch_hz':            round(mean_pitch, 2),
+                'pitch_std':                round(pitch_std, 2),
+                'mean_energy':              round(mean_energy, 6),
+                'speaking_rate':            round(speaking_rate, 4),
+                'pitch_perturbation_ratio': round(pitch_perturbation_ratio, 6),
+                'valence_estimate':         valence_label,
+                'valence_score':            valence_score
+            }
+
+        except Exception as e:
+            logger.error(
+                "[ProsodyService] [extract] Failed on %s [%d-%d ms]: %s",
+                audio_path, start_ms, end_ms, str(e)
+            )
+            return {}
+
+    def _estimate_valence(
+        self,
+        pitch: float,
+        pitch_std: float,
+        energy: float,
+        rate: float
+    ) -> tuple:
+        """
+        Rule-based valence estimation using speaker-relative thresholds.
+
+        Uses relative comparisons against session baselines rather than
+        absolute Hz thresholds to avoid systematic gender bias.
+
+        Returns:
+            (valence_label, valence_score)
+        """
+        conditions = []
+
+        if self._session_pitch_baseline and self._session_pitch_baseline > 0:
+            conditions.append(pitch > self._session_pitch_baseline * 1.05)
+        else:
+            conditions.append(90.0 < pitch < 350.0)
+
+        conditions.append(pitch_std > 20.0)
+
+        if self._session_energy_baseline and self._session_energy_baseline > 0:
+            conditions.append(energy > self._session_energy_baseline * 0.90)
+        else:
+            conditions.append(energy > 0.01)
+
+        conditions.append(rate > 0.55)
+
+        score = sum(conditions) / len(conditions)
+
+        if score >= 0.67:
+            return 'positive', round(score, 3)
+        elif score <= 0.33:
+            return 'negative', round(1.0 - score, 3)
+        else:
+            return 'neutral', round(0.5, 3)


### PR DESCRIPTION
## Summary

RUXAILAB currently runs facial emotion detection and audio-text sentiment as two disconnected pipelines. This PR adds the foundation for fusing all three modalities — facial expression, transcribed text, and voice prosody — into a single confidence-weighted sentiment prediction per usability session segment.

## New Files

### `app/services/prosody_service.py`
Extracts pitch, energy, speaking rate, and pitch perturbation ratio from audio segments using librosa. Key design decisions:

- Uses speaker-relative pitch and energy baselines (exponential moving average across chunks) instead of absolute thresholds — avoids systematic gender bias where a fixed 180 Hz cutoff would favour positive predictions for female speakers (avg ~210 Hz) and negative for male speakers (avg ~120 Hz) regardless of actual sentiment
- Returns `valence_score` (fraction of conditions triggered, 0.0–1.0) as the confidence measure — NOT `speaking_rate`, which measures voiced frame fraction and has no relationship to prediction confidence
- Field renamed from `jitter` to `pitch_perturbation_ratio` to avoid implying clinical validity — this is mean(|diff(f0)|)/mean(f0), not standard Praat-style jitter
- `reset_baseline()` must be called between separate usability sessions

### `app/services/multimodal_engine.py`
Fuses facial, text, and prosody modalities into a single 3-class prediction (positive | neutral | negative):

- All native label spaces normalized via `LABEL_MAP` before fusion (BERTweet POS/NEU/NEG, 7-class facial CNN, 3-class prosody)
- Confidence-weighted voting with proportional weight redistribution when modalities are missing
- Per-request weight overrides passed as method arguments — never mutates `self.weights` — safe under concurrent gunicorn workers
- Engine is designed as a module-level singleton in the route layer

### `app/routes/multimodal_routes.py`
Exposes `POST /multimodal/analyze` with full flask-restx Swagger docs:

- Validates at least one modality is provided
- Builds per-request weight dict as a copy of engine defaults — never writes back to `engine.weights`
- Explicit handling for whitespace-only text, missing `end_ms` for prosody, and malformed weight override payloads

## Example Request
```json
{
  "text": "This interface is really confusing.",
  "facial_emotions": {"Happy": 12.5, "Neutral": 61.0, "Sad": 26.5},
  "audio_path": "static/audio/session_01_task_03.mp3",
  "start_ms": 0,
  "end_ms": 5000
}
```

## Example Response
```json
{
  "status": "success",
  "data": {
    "fused_label": "negative",
    "fused_confidence": 0.6823,
    "modality_scores": {
      "text":    {"label": "negative", "confidence": 0.87, "weight": 0.45},
      "facial":  {"label": "neutral",  "confidence": 0.61, "weight": 0.35},
      "prosody": {"label": "negative", "confidence": 0.42, "weight": 0.20}
    }
  }
}
```

## Relation to GSoC 2026
This implements the core of the Multimodal Sentiment Analysis Engine proposed for GSoC 2026 — demonstrating the architecture, fusion logic, and API design before the coding period begins.